### PR TITLE
Add/fix examples and remove decorator check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When registering you can pass any [options](https://github.com/apache/nano#confi
   })
 ```
 
-This plugin will add the `couch` namespace in your Fastify instance which you can treat exactly like an instance of nano. Inside your routes you can call `this.couch` to access the full range of nano's [methods documented here](https://github.com/apache/nano#getting-started).
+This plugin will add the `couch` namespace in your Fastify instance which you can treat exactly like an instance of nano. Inside your routes you can then access the full range of nano's [methods documented here](https://github.com/apache/nano#getting-started).
 
 **Example**:
 ```js
@@ -52,7 +52,7 @@ fastify.register(require('fastify-couchdb'), {
 
 fastify.get('/rabbit', async (req, reply) => {
   try {
-    const rabbits = this.couch.db.use('rabbits');
+    const rabbits = fastify.couch.db.use('rabbits');
     const body = await rabbits.get('whiterabbit')
     reply.send(body);
   }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# fastify-couchdb examples
+
+This directory contains two examples of using the CouchDB plugin with Fastify.
+
+To run them, make sure you `npm install` the root directory (eg ../) so the dependencies are available.
+
+## callbacks.js
+
+This file details a simple example of registering the `fastify-couchdb` plugin and calling it from a simple GET route. This route will list all known databases on the local CouchDB service. Here we use callbacks to pass error and body information along. The `this` keyword can be used to reference the plugin as `this.couch`.
+
+## async.js 
+
+This file shows the same example using `async/await` syntax rather than callbacks.
+
+## Additional examples
+
+If you would like to add additional examples, please open a PR and feel free to contribute. See [Contributing.md](../CONTRIBUTING.md) for details.

--- a/examples/async.js
+++ b/examples/async.js
@@ -1,0 +1,21 @@
+const fastify = require('fastify')()
+
+const COUCHDB_URL = 'http://localhost:5984'
+
+fastify.register(require('../index'), {url: COUCHDB_URL})
+
+fastify.get('/', async (request, reply) => {
+  const { err, body } = await fastify.couch.db.list()
+  reply.send(err || { databases: body })
+})
+
+const start = async () => {
+  try {
+    await fastify.listen(3000)
+    console.log('Listening on http://127.0.0.1:3000')
+  } catch (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+}
+start()

--- a/examples/callbacks.js
+++ b/examples/callbacks.js
@@ -1,0 +1,22 @@
+// Require the framework and instantiate it
+const fastify = require('fastify')()
+
+const COUCHDB_URL = 'http://localhost:5984'
+
+fastify.register(require('../index'), {url: COUCHDB_URL})
+
+// Declare a route
+fastify.get('/', function (request, reply) {
+  this.couch.db.list(function (err, body) {
+    reply.send(err || { databases: body })
+  })
+})
+
+// Run the server!
+fastify.listen(3000, function (err) {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+  console.log('Listening on http://127.0.0.1:3000')
+})

--- a/index.js
+++ b/index.js
@@ -4,13 +4,9 @@ const fp = require('fastify-plugin')
 const nano = require('nano')
 
 function fastifyCouchDB (fastify, options, next) {
-  if (fastify.hasDecorator('couch')) {
-    next(new Error('fastify-couchdb has already registered'))
-  } else {
-    const couch = nano(options)
-    fastify.decorate('couch', couch)
-    next()
-  }
+  const couch = nano(options)
+  fastify.decorate('couch', couch)
+  next()
 }
 
 module.exports = fp(fastifyCouchDB, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-couchdb",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Fastify CouchDB connection plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Additional examples for the plugin
- Remove decorator check as fastify will error if already registered
- Fix misleading `this` in README.md

This should hopefully address the last of the feed back on https://github.com/fastify/fastify/pull/892.